### PR TITLE
[codex] Fix GitHub Pages deploy paths

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate Pages workflow
+        run: bash scripts/check_pages_workflow.sh
+
       # Restore LFS assets from cache, so that you don't have to check them out every time, which saves GitHub bundle costs.
       - name: Create LFS file list
         run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
@@ -73,13 +76,10 @@ jobs:
 
       - name: Build Release
         run: |
-          trunk build --release --public-url "${GITHUB_REPOSITORY#*/}"
+          trunk build --release --public-url "/${GITHUB_REPOSITORY#*/}/"
 
-      # Optimise the build.
-      - name: Optimize Wasm
-        uses: NiklasEi/wasm-opt-action@v2
-        with:
-          file: dist/*.wasm
+      - name: Validate Pages dist
+        run: bash scripts/check_pages_dist.sh
 
 #      # This step actually creates a branch named gh-pages.
 #      # which is really not what you want if you have 5MB+ in assets.

--- a/scripts/check_pages_dist.sh
+++ b/scripts/check_pages_dist.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+index="dist/index.html"
+
+if [[ ! -f "${index}" ]]; then
+  cat >&2 <<'ERROR'
+Missing dist/index.html.
+Run: trunk build --release --public-url /death-arena/
+ERROR
+  exit 1
+fi
+
+if rg -q "from 'death-arena/" "${index}"; then
+  cat >&2 <<'ERROR'
+Generated module import uses a bare specifier.
+Expected root-relative imports starting with /death-arena/.
+ERROR
+  exit 1
+fi
+
+if rg -q 'href="death-arena/|module_or_path: '\''death-arena/' "${index}"; then
+  cat >&2 <<'ERROR'
+Generated asset URL is relative to the current page.
+Expected root-relative URLs starting with /death-arena/.
+ERROR
+  exit 1
+fi
+
+if rg -q "/death-arena/death-arena/" "${index}"; then
+  cat >&2 <<'ERROR'
+Generated asset URL contains a duplicated GitHub Pages base path.
+Expected exactly one /death-arena/ prefix.
+ERROR
+  exit 1
+fi
+
+if ! rg -q "from '/death-arena/[^']+\\.js'" "${index}"; then
+  cat >&2 <<'ERROR'
+Generated module import does not use the GitHub Pages base path.
+Expected: from '/death-arena/<asset>.js'
+ERROR
+  exit 1
+fi
+
+if ! rg -q "module_or_path: '/death-arena/[^']+_bg\\.wasm'" "${index}"; then
+  cat >&2 <<'ERROR'
+Generated wasm loader path does not use the GitHub Pages base path.
+Expected: module_or_path: '/death-arena/<asset>_bg.wasm'
+ERROR
+  exit 1
+fi

--- a/scripts/check_pages_workflow.sh
+++ b/scripts/check_pages_workflow.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow=".github/workflows/pages.yml"
+
+if ! rg -q 'trunk build --release --public-url "/\$\{GITHUB_REPOSITORY#\*/\}/"' "${workflow}"; then
+  cat >&2 <<'ERROR'
+Pages workflow must build with an absolute GitHub Pages base path.
+Use: trunk build --release --public-url "/${GITHUB_REPOSITORY#*/}/"
+ERROR
+  exit 1
+fi
+
+if rg -q "wasm-opt-action|wasm-opt|dist/\\*\\.wasm" "${workflow}"; then
+  cat >&2 <<'ERROR'
+Pages workflow mutates wasm after Trunk builds dist.
+That can invalidate Trunk-generated resource integrity hashes.
+Let Trunk own wasm optimisation before it writes final artefacts.
+ERROR
+  exit 1
+fi
+
+if ! rg -q "bash scripts/check_pages_dist.sh" "${workflow}"; then
+  cat >&2 <<'ERROR'
+Pages workflow must validate generated dist asset paths after Trunk builds.
+Use: bash scripts/check_pages_dist.sh
+ERROR
+  exit 1
+fi


### PR DESCRIPTION
## What changed
- Build Pages with an absolute GitHub Pages public URL.
- Remove post-build wasm mutation after Trunk writes dist.
- Add workflow and dist guards for generated Pages asset paths.

## Why
The live Pages HTML generated relative `death-arena/...` module and wasm paths, causing bare module specifier errors and `/death-arena/death-arena/...` 404s.

## Validation
- `trunk build --release --public-url /death-arena/`
- `bash scripts/check_pages_workflow.sh`
- `bash scripts/check_pages_dist.sh`
- local preview returned 200 for `/death-arena/`, JS, and wasm
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`