### PR TITLE
[codex] Use grep in Pages checks

### DIFF
--- a/scripts/check_pages_dist.sh
+++ b/scripts/check_pages_dist.sh
@@ -11,7 +11,7 @@ ERROR
   exit 1
 fi
 
-if rg -q "from 'death-arena/" "${index}"; then
+if grep -Fq "from 'death-arena/" "${index}"; then
   cat >&2 <<'ERROR'
 Generated module import uses a bare specifier.
 Expected root-relative imports starting with /death-arena/.
@@ -19,7 +19,7 @@ ERROR
   exit 1
 fi
 
-if rg -q 'href="death-arena/|module_or_path: '\''death-arena/' "${index}"; then
+if grep -Eq "href=\"death-arena/|module_or_path: 'death-arena/" "${index}"; then
   cat >&2 <<'ERROR'
 Generated asset URL is relative to the current page.
 Expected root-relative URLs starting with /death-arena/.
@@ -27,7 +27,7 @@ ERROR
   exit 1
 fi
 
-if rg -q "/death-arena/death-arena/" "${index}"; then
+if grep -Fq "/death-arena/death-arena/" "${index}"; then
   cat >&2 <<'ERROR'
 Generated asset URL contains a duplicated GitHub Pages base path.
 Expected exactly one /death-arena/ prefix.
@@ -35,7 +35,7 @@ ERROR
   exit 1
 fi
 
-if ! rg -q "from '/death-arena/[^']+\\.js'" "${index}"; then
+if ! grep -Eq "from '/death-arena/[^']+\\.js'" "${index}"; then
   cat >&2 <<'ERROR'
 Generated module import does not use the GitHub Pages base path.
 Expected: from '/death-arena/<asset>.js'
@@ -43,7 +43,7 @@ ERROR
   exit 1
 fi
 
-if ! rg -q "module_or_path: '/death-arena/[^']+_bg\\.wasm'" "${index}"; then
+if ! grep -Eq "module_or_path: '/death-arena/[^']+_bg\\.wasm'" "${index}"; then
   cat >&2 <<'ERROR'
 Generated wasm loader path does not use the GitHub Pages base path.
 Expected: module_or_path: '/death-arena/<asset>_bg.wasm'

--- a/scripts/check_pages_workflow.sh
+++ b/scripts/check_pages_workflow.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 workflow=".github/workflows/pages.yml"
 
-if ! rg -q 'trunk build --release --public-url "/\$\{GITHUB_REPOSITORY#\*/\}/"' "${workflow}"; then
+if ! grep -Fq 'trunk build --release --public-url "/${GITHUB_REPOSITORY#*/}/"' "${workflow}"; then
   cat >&2 <<'ERROR'
 Pages workflow must build with an absolute GitHub Pages base path.
 Use: trunk build --release --public-url "/${GITHUB_REPOSITORY#*/}/"
@@ -11,7 +11,7 @@ ERROR
   exit 1
 fi
 
-if rg -q "wasm-opt-action|wasm-opt|dist/\\*\\.wasm" "${workflow}"; then
+if grep -Eq "wasm-opt-action|wasm-opt|dist/\\*\\.wasm" "${workflow}"; then
   cat >&2 <<'ERROR'
 Pages workflow mutates wasm after Trunk builds dist.
 That can invalidate Trunk-generated resource integrity hashes.
@@ -20,7 +20,7 @@ ERROR
   exit 1
 fi
 
-if ! rg -q "bash scripts/check_pages_dist.sh" "${workflow}"; then
+if ! grep -Fq "bash scripts/check_pages_dist.sh" "${workflow}"; then
   cat >&2 <<'ERROR'
 Pages workflow must validate generated dist asset paths after Trunk builds.
 Use: bash scripts/check_pages_dist.sh


### PR DESCRIPTION
## What changed
- Replace `rg` usage in Pages guard scripts with `grep`.

## Why
The GitHub Pages runner does not have ripgrep installed, so the deploy failed before the build step.

## Validation
- `bash scripts/check_pages_workflow.sh`
- `bash scripts/check_pages_dist.sh`
- pre-commit hook: `cargo check`, `cargo fmt -- --check`, `cargo clippy -- -D warnings`, `cargo test`